### PR TITLE
fix: show hours in _fmt_clock for durations >= 1 hour

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -156,7 +156,11 @@ def _parse_metadata(raw: str) -> Dict[str, Any]:
 
 def _fmt_clock(seconds: float) -> str:
     seconds = max(0, int(round(seconds)))
-    return f"{seconds // 60}:{seconds % 60:02d}"
+    hours, rem = divmod(seconds, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f"{hours}:{minutes:02d}:{secs:02d}"
+    return f"{minutes}:{secs:02d}"
 
 
 def _human_size(num_bytes: int) -> str:


### PR DESCRIPTION
**Summary**

-  _fmt_clock in demo/app.py previously formatted any duration as M:SS, so durations of an hour or more (e.g. 3661s) displayed as 61:01 instead of 1:01:01.
-  Now formats as H:MM:SS when the duration is at least an hour, otherwise falls back to the existing M:SS format.