### PR TITLE
fix: theme toggle and keep theme toggle state consistent even after refresh

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -450,7 +450,13 @@ HEAD = """
 (function () {
     function syncTheme(isDark) {
         document.documentElement.classList.toggle('dark', isDark);
-        if (document.body) document.body.classList.toggle('dark', isDark);
+        if (document.body) {
+            document.body.classList.toggle('dark', isDark);
+            return;
+        }
+        document.addEventListener('DOMContentLoaded', function () {
+            if (document.body) document.body.classList.toggle('dark', isDark);
+        }, { once: true });
     }
     var isDark = true;
   try {
@@ -461,9 +467,6 @@ HEAD = """
     }
     // Keep html and body in sync so first toggle after refresh does not drift.
     syncTheme(isDark);
-    if (!document.body) {
-        document.addEventListener('DOMContentLoaded', function () { syncTheme(isDark); }, { once: true });
-    }
 })();
 </script>
 """

--- a/demo/app.py
+++ b/demo/app.py
@@ -448,25 +448,18 @@ footer {{ display: none !important; }}
 HEAD = """
 <script>
 (function () {
-    function syncTheme(isDark) {
-        document.documentElement.classList.toggle('dark', isDark);
-        if (document.body) {
-            document.body.classList.toggle('dark', isDark);
-            return;
-        }
+    var pref = 'dark';
+    try { pref = localStorage.getItem('mk-theme') || 'dark'; } catch (e) {}
+    var isDark = pref !== 'light';
+
+    document.documentElement.classList.toggle('dark', isDark);
+    if (document.body) {
+        document.body.classList.toggle('dark', isDark);
+    } else {
         document.addEventListener('DOMContentLoaded', function () {
             if (document.body) document.body.classList.toggle('dark', isDark);
         }, { once: true });
     }
-    var isDark = true;
-  try {
-    var pref = localStorage.getItem('mk-theme') || 'dark';
-        isDark = pref !== 'light';
-    } catch (e) {
-        isDark = true;
-    }
-    // Keep html and body in sync so first toggle after refresh does not drift.
-    syncTheme(isDark);
 })();
 </script>
 """
@@ -474,10 +467,10 @@ HEAD = """
 # Masthead toggle: flip the .dark class on <html>, persist the choice, no reload.
 THEME_TOGGLE_JS = """
 () => {
-    var isDark = document.documentElement.classList.contains('dark') || (document.body && document.body.classList.contains('dark'));
-    document.documentElement.classList.toggle('dark', !isDark);
-    if (document.body) document.body.classList.toggle('dark', !isDark);
-    try { localStorage.setItem('mk-theme', !isDark ? 'dark' : 'light'); } catch (e) {}
+    var isDark = !document.documentElement.classList.contains('dark');
+    document.documentElement.classList.toggle('dark', isDark);
+    if (document.body) document.body.classList.toggle('dark', isDark);
+    try { localStorage.setItem('mk-theme', isDark ? 'dark' : 'light'); } catch (e) {}
 }
 """
 

--- a/demo/app.py
+++ b/demo/app.py
@@ -448,12 +448,22 @@ footer {{ display: none !important; }}
 HEAD = """
 <script>
 (function () {
+    function syncTheme(isDark) {
+        document.documentElement.classList.toggle('dark', isDark);
+        if (document.body) document.body.classList.toggle('dark', isDark);
+    }
+    var isDark = true;
   try {
     var pref = localStorage.getItem('mk-theme') || 'dark';
-    document.documentElement.classList.toggle('dark', pref !== 'light');
-  } catch (e) {
-    document.documentElement.classList.add('dark');
-  }
+        isDark = pref !== 'light';
+    } catch (e) {
+        isDark = true;
+    }
+    // Keep html and body in sync so first toggle after refresh does not drift.
+    syncTheme(isDark);
+    if (!document.body) {
+        document.addEventListener('DOMContentLoaded', function () { syncTheme(isDark); }, { once: true });
+    }
 })();
 </script>
 """
@@ -461,8 +471,10 @@ HEAD = """
 # Masthead toggle: flip the .dark class on <html>, persist the choice, no reload.
 THEME_TOGGLE_JS = """
 () => {
-  var dark = document.documentElement.classList.toggle('dark');
-  try { localStorage.setItem('mk-theme', dark ? 'dark' : 'light'); } catch (e) {}
+    var isDark = document.documentElement.classList.contains('dark') || (document.body && document.body.classList.contains('dark'));
+    document.documentElement.classList.toggle('dark', !isDark);
+    if (document.body) document.body.classList.toggle('dark', !isDark);
+    try { localStorage.setItem('mk-theme', !isDark ? 'dark' : 'light'); } catch (e) {}
 }
 """
 


### PR DESCRIPTION
This PR fixes theme toggle and maintain theme state even after refresh.

**What was wrong:**
Theme toggle not working.
After refresh, first toggle could behave incorrectly (often flipping to dark unexpectedly).

**What was changed:**

Theme toggle works by sync theme to both html and body.
On intial render the app now reads mk-theme from localStorage and applies the same mode consistently.

**Result:**
Theme toggle works
Refresh keeps the selected theme.